### PR TITLE
feat(matching): add fallback parsing for missing ingredients_cleaned

### DIFF
--- a/backend/app/services/matching.py
+++ b/backend/app/services/matching.py
@@ -3,6 +3,7 @@
 from backend import models
 from sqlalchemy.orm import Session
 from typing import List, Set
+from backend.app.utils.ingredient_parser import parse_agricook_ingredients, parse_openapi_ingredients
 
 def clean_input_ingredients(input_text: str) -> Set[str]:
     """
@@ -18,19 +19,28 @@ def clean_input_ingredients(input_text: str) -> Set[str]:
 
 def auto_match_foods_from_input(input_text: str, db: Session) -> List[int]:
     """
-    사용자 입력 재료를 기반으로, ingredients_cleaned에 1개라도 포함된 레시피의 food_id를 반환
+    사용자 입력 재료를 기반으로, ingredients_cleaned 또는 fallback 파싱을 통해
+    일치하는 재료가 하나라도 포함된 레시피의 food_id를 반환
     """
     user_ingredients: Set[str] = clean_input_ingredients(input_text)
     if not user_ingredients:
         return []
 
     matched_food_ids: Set[int] = set()
-
     recipes: List[models.Recipe] = db.query(models.Recipe).all()
+
     for recipe in recipes:
-        if not recipe.ingredients_cleaned:
+        if recipe.ingredients_cleaned:
+            recipe_ingredients: Set[str] = set(recipe.ingredients_cleaned)
+        elif recipe.ingredients:
+            if recipe.source_type == "agricook":
+                parsed = parse_agricook_ingredients(recipe.ingredients)
+            else:
+                parsed = parse_openapi_ingredients(recipe.ingredients)
+            recipe_ingredients = set(parsed)
+        else:
             continue
-        recipe_ingredients: Set[str] = set(recipe.ingredients_cleaned)
+
         if user_ingredients & recipe_ingredients:
             matched_food_ids.add(recipe.food_id)
 


### PR DESCRIPTION
현재 일부 레시피에 ingredients_cleaned 필드가 누락되거나 비어 있을 가능성에 대비하여,
matching.py 내부에 fallback 로직을 추가했습니다.

- ingredients_cleaned가 존재하지 않을 경우, source_type에 따라 파서를 선택해 실시간 파싱
  - public → parse_openapi_ingredients
  - agricook → parse_agricook_ingredients
- 이 fallback은 평상시에는 작동하지 않으며, 정제 필드가 빠진 예외 상황에서만 사용됩니다.
- 데이터 정합성이 확보된 경우 성능 부담 없이 동작합니다.

예외 상황에 대한 안전망 역할을 하므로, 포함해두는 편이 더 안정적입니다.
